### PR TITLE
Support calling the successCallback of login() from handleOpenURL call

### DIFF
--- a/native/ios/FacebookConnectPlugin.h
+++ b/native/ios/FacebookConnectPlugin.h
@@ -19,6 +19,6 @@
 }
 
 @property (nonatomic, retain) Facebook *facebook;
-
+@property (nonatomic, copy) NSString* loginCallbackId;
 
 @end


### PR DESCRIPTION
Support calling the successCallback of login() from handleOpenURL call (after UI login from Mobile Safari/Facebook app).

**NOTE:** this only works if the PhoneGap app supports multi-tasking. Also, the FB.Login callback must **NOT** call any interactive UI like alert()
