### PR TITLE
The 'e' in the login callback made me think FB returned an error

### DIFF
--- a/example/www/index.html
+++ b/example/www/index.html
@@ -76,8 +76,12 @@
             
             function login() {
                 FB.login(
-                    function(e) {
-                        alert(e);
+                    function(response) {
+                        if (response.session) {
+                            alert('logged in');
+                        } else {
+                            alert('not logged in');
+                        }
                     },
                     { perms: "email" }
                 );


### PR DESCRIPTION
The 'e' in the login callback made me think FB returned an error - I think its more clear to call it response and use the same code from getLoginStatus.
