### PR TITLE
Prevent Javascript alert when user cancels Android webview login.

### DIFF
--- a/native/android/src/com/phonegap/facebook/ConnectPlugin.java
+++ b/native/android/src/com/phonegap/facebook/ConnectPlugin.java
@@ -225,7 +225,7 @@ public class ConnectPlugin extends Plugin {
 
         public void onCancel() {
             Log.d(TAG, "cancel");
-            this.fba.error("Cancelled", this.fba.callbackId);
+            this.fba.success(new JSONObject(), this.fba.callbackId);
         }
     }
 }


### PR DESCRIPTION
As specified in the facebook-js-sdk, the success callback should be called
with no session when the user cancels. For more info see:
https://github.com/davejohnson/phonegap-plugin-facebook-connect/issues/84
