### PR TITLE
Handle `session.expires == 0` well, allowing `offline_access` to properly function

### DIFF
--- a/www/pg-plugin-fb-connect.js
+++ b/www/pg-plugin-fb-connect.js
@@ -8,9 +8,17 @@ PG.FB = {
       document.body.appendChild(elem);
     }
     PhoneGap.exec(function() {
-      var session = JSON.parse(localStorage.getItem('pg_fb_session') || '{"expires":0}');
-      if (session && session.expires > new Date().valueOf()) {
-        FB.Auth.setSession(session, 'connected');
+      var storage_session = localStorage.getItem('pg_fb_session');
+      if (storage_session) {
+          // If no key is present in localStorage, storage_session will be
+          // empty and JSON.parse would cause an exception
+          var session = JSON.parse(storage_session);
+
+          // When the offline_access permission is used, session.expires = "0"
+          // (Note the implicit typecasting going on)
+          if (session.expires == 0 || session.expires > new Date().valueOf()) {
+              FB.Auth.setSession(session, 'connected');
+          }
       }
       console.log('PhoneGap Facebook Connect plugin initialized successfully.');
     }, (fail?fail:null), 'com.phonegap.facebook.Connect', 'init', [apiKey]);


### PR DESCRIPTION
As stated in [this question](http://stackoverflow.com/questions/7711097/android-facebook-app-access-token-expiry-expires-in-is-always-0), the value of expires becomes `0` for sessions with the `offline_access` permission.

This patch has been tested to work with both `offline_access` as well as normal tokens and seems to perform fine. It should also clarify and cleanup the current code a bit. This should fix #56 and can be considered a supplement to #19.
