### PR TITLE
Added oAuth support for Android: Fixes issue #56 (same error, different cause/bug)

### DIFF
--- a/native/android/src/com/phonegap/facebook/ConnectPlugin.java
+++ b/native/android/src/com/phonegap/facebook/ConnectPlugin.java
@@ -159,12 +159,22 @@ public class ConnectPlugin extends Plugin {
     public JSONObject getResponse() {
         String response = "{"+
             "\"status\": \""+(facebook.isSessionValid() ? "connected" : "unknown")+"\","+
+            /* old school 
             "\"session\": {"+
               "\"access_token\": \""+facebook.getAccessToken()+"\","+
               "\"expires\": \""+facebook.getAccessExpires()+"\","+
               "\"session_key\": true,"+
               "\"sig\": \"...\","+
               "\"uid\": \""+this.userId+"\""+
+              */
+             //new school: works with oAuth 
+              "\"authResponse\": {"+
+              "\"accessToken\": \""+facebook.getAccessToken()+"\","+
+              "\"expiresIn\": \""+facebook.getAccessExpires()+"\","+
+              "\"session_key\": true,"+
+              "\"sig\": \"...\","+
+              "\"userId\": \""+this.userId+"\""+
+              
             "}"+
           "}";
 


### PR DESCRIPTION
Fixed the "access token must be used to query information about the current user" error for Android in Phongap1.4.1. The new SDK is expecting "authResponse" but getting "session" from the plugin. Not sure what else might need to be returned (i.e signedRequest???) but it seems to work for FB.api('/me') calls. 
