### PR TITLE
Make error alerts more user friendly

### DIFF
--- a/lib/facebook-js-patch
+++ b/lib/facebook-js-patch
@@ -567,13 +567,13 @@ index a4d3007..a62fb82 100644
 +    if (FB._nativeInterface) {
 +        switch (params.method) {
 +            case 'auth.login':
-+                FB._nativeInterface.login(params, cb, function(e) {alert('PhoneGap Facebook Connect plugin fail on login!' + e);});
++                FB._nativeInterface.login(params, cb, function(e) {alert('Facebook login failed: ' + e);});
 +                break;
 +            case 'auth.logout':
-+                FB._nativeInterface.logout(cb, function(e) {alert('PhoneGap Facebook Connect plugin fail on logout!');});
++                FB._nativeInterface.logout(cb, function(e) {alert('Facebook logout failed.');});
 +                break;
 +            case 'auth.status':
-+                FB._nativeInterface.getLoginStatus(cb, function(e) {alert('PhoneGap Facebook Connect plugin fail on auth.status!');});
++                FB._nativeInterface.getLoginStatus(cb, function(e) {alert('Facebook error (auth.status)');});
 +                break;
 +        }
 +        return;

--- a/lib/facebook_js_sdk.js
+++ b/lib/facebook_js_sdk.js
@@ -5106,30 +5106,29 @@ FB.provide('', {
     // If the nativeInterface arg is specified then call out to the nativeInterface 
     // which uses the native app rather than using the iframe / popup web
     if (FB._nativeInterface) {
-        switch (params.method) {
             case 'auth.login':
-                FB._nativeInterface.login(params, cb, function(e) {alert('Cordova Facebook Connect plugin fail on login!' + e);});
+                FB._nativeInterface.login(params, cb, function(e) { alert('Facebook login failed: ' + e);});
                 break;
             case 'permissions.request':
-                FB._nativeInterface.login(params, cb, function(e) {alert('Cordova Facebook Connect plugin fail on login!' + e);});
+                FB._nativeInterface.login(params, cb, function(e) {alert('Facebook login failed:' + e);});
                 break;
             case 'permissions.oauth':
-                FB._nativeInterface.login(params, cb, function(e) {alert('Cordova Facebook Connect plugin fail on login!' + e);});
+                FB._nativeInterface.login(params, cb, function(e) {alert('Facebook login failed: ' + e);});
                 break;
             case 'auth.logout':
-                FB._nativeInterface.logout(cb, function(e) {alert('Cordova Facebook Connect plugin fail on logout!');});
+                FB._nativeInterface.logout(cb, function(e) {alert('Facebook logout failed.');});
                 break;
             case 'auth.status':
-                FB._nativeInterface.getLoginStatus(cb, function(e) {alert('Cordova Facebook Connect plugin fail on auth.status!');});
+                FB._nativeInterface.getLoginStatus(cb, function(e) {alert('Facebook error (auth.status)');});
                 break;
             case 'login.status':
-                FB._nativeInterface.getLoginStatus(cb, function(e) {alert('Cordova Facebook Connect plugin fail on auth.status!');});
+                FB._nativeInterface.getLoginStatus(cb, function(e) {alert('Facebook error (auth.status)');});
                 break;
             case 'feed':
-                FB._nativeInterface.dialog(params, cb, function(e) {alert('Cordova Facebook Connect plugin fail on auth.status!');});
+                FB._nativeInterface.dialog(params, cb, function(e) {alert('Facebook error (auth.status)');});
                 break;
             case 'apprequests':
-                FB._nativeInterface.dialog(params, cb, function(e) {alert('Cordova Facebook Connect plugin fail on auth.status!');});
+                FB._nativeInterface.dialog(params, cb, function(e) {alert('Facebook error (auth.status)');});
             break;
         }
         return;


### PR DESCRIPTION
Change text from e.g.
 Cordova Facebook Connect plugin fail on login!Cancelled
to
 Facebook login failed: Cancelled
Users don't know what a 'plugin' is, and cancelling the FB login dialog is a normal event.
