### PR TITLE
Cancel button on Feed Dialog does not trigger callback function (Android)

### DIFF
--- a/native/android/src/org/apache/cordova/facebook/ConnectPlugin.java
+++ b/native/android/src/org/apache/cordova/facebook/ConnectPlugin.java
@@ -394,7 +394,9 @@ public class ConnectPlugin extends Plugin {
 			    // will include the resulting request id. For a feed dialog, the "post_id"
 			    // parameter will include the resulting post id.
 				// Note: If the user clicks on the Cancel button, the parameter will be empty
-				if (values.size() > 0) {
+				// NOTE: before my proposed changes the callback function is not called at all!
+				// NOTE: this is not in sync with the behavior under iOS see my comments attached
+				// if (values.size() > 0) {
 					JSONObject response = new JSONObject();
 					try {
 						Set<String> keys = values.keySet();
@@ -406,10 +408,10 @@ public class ConnectPlugin extends Plugin {
 					}
 					this.fba.success(new PluginResult(PluginResult.Status.OK, response), 
 							this.fba.dialogCallbackId);
-				} else {
+				/* } else {
 					this.fba.success(new PluginResult(PluginResult.Status.OK), 
 							this.fba.dialogCallbackId);
-				}
+				}*/
 			}
 		}
 	}


### PR DESCRIPTION
When calling FB.ui for Dialog (method=feed):

iOS version returns upon:
send: response={"post_id":"???"}
cancel: response={}

BUT android differs and return upon:
send: response={"post_id":"???"}
cancel: callback function NOT called at all

Thus my proposed changes in native/android/src/org/apache/cordova/facebook/ConnectPlugin.java.
https://github.com/robert4os/phonegap-plugin-facebook-connect/commit/558bc6aedfe163b42502f229d7598580ddfbae70
