### PR TITLE
Fixes #248 - phonegap-2.4.0 terminates in IOS

### DIFF
--- a/native/ios/FacebookConnectPlugin.m
+++ b/native/ios/FacebookConnectPlugin.m
@@ -308,6 +308,7 @@
     #else
         [method release];
         [params release];
+        [options release];
     #endif
     
     [super writeJavascript:nil];


### PR DESCRIPTION
With Cordova 2.4.0, NSJSONSerialization is used, thus objects returned are immutable: http://developer.apple.com/library/ios/#documentation/Foundation/Reference/NSJSONSerialization_Class/Reference/Reference.html

Any NSDictionaries from the arguments should be considered immutable.
