### PR TITLE
Class rewritten to get rid of deprecated APIs and make use of current Facebook API

### DIFF
--- a/src/android/ConnectPlugin.java
+++ b/src/android/ConnectPlugin.java
@@ -1,314 +1,149 @@
 package org.apache.cordova.facebook;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.util.Iterator;
-
-import org.apache.cordova.api.Plugin;
-import org.apache.cordova.api.PluginResult;
+import android.content.Intent;
+import android.util.Log;
+import com.facebook.Request;
+import com.facebook.Response;
+import com.facebook.Session;
+import com.facebook.SessionState;
+import com.facebook.model.GraphUser;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.PluginResult;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import android.content.Intent;
-import android.content.SharedPreferences;
-import android.os.Bundle;
-import android.preference.PreferenceManager;
-import android.util.Log;
+/**
+ *
+ * @author Alessandro Polverini <alex@nibbles.it>
+ */
+public class ConnectPlugin extends CordovaPlugin {
 
-import com.facebook.android.DialogError;
-import com.facebook.android.Facebook;
-import com.facebook.android.Facebook.DialogListener;
-import com.facebook.android.FacebookError;
+  public final static String TAG = "Web/ConnectPlugin";
+  CallbackContext lastCallbackContext;
 
-public class ConnectPlugin extends Plugin {
+  @Override
+  public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) throws JSONException {
 
-    public static final String SINGLE_SIGN_ON_DISABLED = "service_disabled";
-    private final String TAG = "ConnectPlugin";
+    // TODO: Ask for extented permissions sent by the plugin call
 
-    private Facebook facebook;
-    private String userId;
-    //used for dialog auth
-    private String[] permissions = new String[] {};
-    private String callbackId;
-    private Bundle paramBundle;
-    private String method;
+    Session activeSession = Session.getActiveSession();
+    if ("login".equals(action)) {
+      Log.d(TAG, "[FACEBOOK] LOGIN");
+      if (activeSession == null) {
+        Log.d(TAG, "[FACEBOOK] ActiveSession NULL");
+      } else {
+        Log.d(TAG, "token: " + activeSession.getAccessToken());
+        Log.d(TAG, "isClosed: " + activeSession.isClosed());
+        Log.d(TAG, "isOpened: " + activeSession.isOpened());
+        Log.d(TAG, "expirationDate: " + activeSession.getExpirationDate());
+        SessionState state = activeSession.getState();
+        Log.d(TAG, "state: " + state);
+      }
+      lastCallbackContext = callbackContext;
+      cordova.setActivityResultCallback(this);
+      cordova.getThreadPool().execute(new Runnable() {
+        public void run() {
+          Session.openActiveSession(cordova.getActivity(), true, new Session.StatusCallback() {
+            // callback when session changes state
+            @Override
+            public void call(Session session, SessionState state, Exception exception) {
+              Log.d(TAG, "[StatusCallback] SESSIONSTATE.isOpened: " + state.isOpened() + " token: " + session.getAccessToken());
+              if (session.isOpened()) {
+                if (lastCallbackContext != null) {
+                  lastCallbackContext.success(getLoginStatus(session));
+                  lastCallbackContext = null;
+                }
+              }
+            }
+          });
+        }
+      });
+      PluginResult pr = new PluginResult(PluginResult.Status.NO_RESULT);
+      pr.setKeepCallback(true);
+      callbackContext.sendPluginResult(pr);
 
-    @Override
-    public PluginResult execute(String action, JSONArray args, final String callbackId) {
+    } else if ("me".equals(action)) {
+      Log.d(TAG, "Executing 'me' with activesession: " + activeSession + (activeSession != null ? activeSession.isOpened() : ""));
+      if (activeSession == null || activeSession.isClosed()) {
+        callbackContext.error("sessionClosed");
+      } else {
+        Request.executeMeRequestAsync(activeSession, new Request.GraphUserCallback() {
+          // callback after Graph API response with user object
+          @Override
+          public void onCompleted(GraphUser user, Response response) {
+            Log.d(TAG, "[me onCompleted] user: " + user + " response: " + response);
+            if (user != null) {
+              callbackContext.success(userToJSON(user));
+            }
+          }
+        });
         PluginResult pr = new PluginResult(PluginResult.Status.NO_RESULT);
         pr.setKeepCallback(true);
+        callbackContext.sendPluginResult(pr);
+      }
 
-        if (action.equals("init")) {
-            try {
-                String appId = args.getString(0);
-
-                facebook = new Facebook(appId);
-
-                Log.d(TAG, "init: Initializing plugin.");
-
-                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(cordova.getActivity());
-                String access_token = prefs.getString("access_token", null);
-                Long expires = prefs.getLong("access_expires", -1);
-
-                if (access_token != null && expires != -1) {
-                    this.facebook.setAccessToken(access_token);
-                    this.facebook.setAccessExpires(expires);
-                	  try {
-                        JSONObject o = new JSONObject(this.facebook.request("/me"));
-                        this.userId = o.getString("id");
-                    } catch (MalformedURLException e) {
-                       
-                        e.printStackTrace();
-                    } catch (IOException e) {
-                       
-                        e.printStackTrace();
-                    } catch (JSONException e) {
-                       
-                        e.printStackTrace();
-                    }
-                }
-
-                if(facebook.isSessionValid() && this.userId != null) {
-                    return new PluginResult(PluginResult.Status.OK, this.getResponse());
-                }
-                else {
-                    return new PluginResult(PluginResult.Status.NO_RESULT);
-                }
-            } catch (JSONException e) {
-               
-                e.printStackTrace();
-                return new PluginResult(PluginResult.Status.ERROR, "Invalid JSON args used. expected a string as the first arg.");
-            }
+    } else if ("logout".equals(action)) {
+      boolean clearToken = args != null && args.optBoolean(0);
+      Log.d(TAG, "FACEBOOK LOGOUT - clearToken: " + clearToken);
+      if (activeSession != null) {
+        if (clearToken) {
+          activeSession.closeAndClearTokenInformation();
+        } else {
+          activeSession.close();
         }
+      }
+      callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, "logout"));
 
-        else if (action.equals("login")) {
-            if (facebook != null) {
-            	final ConnectPlugin me = this;
-                String[] permissions = new String[args.length()];
-                try {
-                    for (int i=0; i<args.length(); i++) {
-                        permissions[i] = args.getString(i);
-                    }
-                } catch (JSONException e1) {
-                   
-                    e1.printStackTrace();
-                    return new PluginResult(PluginResult.Status.ERROR, "Invalid JSON args used. Expected a string array of permissions.");
-                }
-                cordova.setActivityResultCallback(this);
-//                this.ctx.setActivityResultCallback(this);
-                this.permissions = permissions;
-                this.callbackId = callbackId;
-                Runnable runnable = new Runnable() {
-                    public void run() {
-                        me.facebook.authorize(cordova.getActivity(), me.permissions, new AuthorizeListener(me));
-                    };
-                };
-                cordova.getActivity().runOnUiThread(runnable);
-//                this.ctx.runOnUiThread(runnable);
-            } else {
-                pr = new PluginResult(PluginResult.Status.ERROR, "Must call init before login.");
-            }
-        }
+    } else if ("getLoginStatus".equals(action)) {
+      Log.d(TAG, "LOGINSTATUS");
+      callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, getLoginStatus(activeSession)));
 
-        else if (action.equals("logout")) {
-            if (facebook != null) {
-                try {
-                    facebook.logout(cordova.getActivity());
+    } else if ("init".equals(action)) {
+      Log.i(TAG, "Deprecated call to init");
+      // Do nothing, only for compatibility with old interface
+      callbackContext.success();
 
-                    SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this.cordova.getActivity());
-                    prefs.edit().putLong("access_expires", -1).commit();
-                    prefs.edit().putString("access_token", null).commit();
-                } catch (MalformedURLException e) {
-                   
-                    e.printStackTrace();
-                    pr = new PluginResult(PluginResult.Status.MALFORMED_URL_EXCEPTION, "Error logging out.");
-                } catch (IOException e) {
-                   
-                    e.printStackTrace();
-                    pr = new PluginResult(PluginResult.Status.IO_EXCEPTION, "Error logging out.");
-                }
-                pr = new PluginResult(PluginResult.Status.OK, getResponse());
-            } else {
-                pr = new PluginResult(PluginResult.Status.ERROR, "Must call init before logout.");
-            }
-        }
-
-        else if (action.equals("getLoginStatus")) {
-            if (facebook != null) {
-                pr = new PluginResult(PluginResult.Status.OK, getResponse());
-            } else {
-                pr = new PluginResult(PluginResult.Status.ERROR, "Must call init before getLoginStatus.");
-            }
-        }
-        
-        else if (action.equals("showDialog")) {
-        	if (facebook != null) {
-        		Bundle collect = new Bundle();
-        		JSONObject params = null;
-        		try {
-        			params = args.getJSONObject(0);
-        		} catch (JSONException e) {
-        			params = new JSONObject();
-        		}
-        		
-        		final ConnectPlugin me = this;
-        		Iterator<?> iter = params.keys();
-        		while (iter.hasNext()) {
-        			String key = (String) iter.next();
-        			if (key.equals("method")) {
-        				try {
-        					this.method = params.getString(key);
-        				} catch (JSONException e) {
-        					Log.w(TAG, "Nonstring method parameter provided to dialog");
-        				}
-        			} else {
-        				try {
-        					collect.putString(key, params.getString(key));
-        				} catch (JSONException e) {
-        					// Need to handle JSON parameters
-        					Log.w(TAG, "Nonstring parameter provided to dialog discarded");
-        				}
-        			}
-        		}
-        		this.paramBundle =  new Bundle(collect);
-        		this.callbackId = callbackId;
-        		Runnable runnable = new Runnable() {
-        			public void run() {
-        				me.facebook.dialog (me.cordova.getActivity(), me.method , me.paramBundle , new UIDialogListener(me));
-        			};
-        		};
-        		cordova.getActivity().runOnUiThread(runnable);
-//        		this.ctx.runOnUiThread(runnable);
-        	} else {
-        		pr = new PluginResult(PluginResult.Status.ERROR, "Must call init before showDialog.");
-        	}
-        	
-        }
-
-        return pr;
+    } else {
+      return false;
     }
+    return true;
+  }
 
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
+  public JSONObject userToJSON(GraphUser user) {
+    Map<String, Object> response = new HashMap<String, Object>();
+    response.put("id", user.getId());
+    response.put("username", user.getUsername());
+    response.put("name", user.getName());
+    response.put("firstName", user.getFirstName());
+    response.put("middleName", user.getMiddleName());
+    response.put("lastName", user.getLastName());
+    response.put("link", user.getLink());
+    response.put("birthday", user.getBirthday());
+    return new JSONObject(response);
+  }
 
-        facebook.authorizeCallback(requestCode, resultCode, data);
+  public JSONObject getLoginStatus(Session fbSession) {
+    Map<String, Object> response = new HashMap<String, Object>();
+    if (fbSession != null && fbSession.isOpened()) {
+      response.put("status", "connected");
+      response.put("accessToken", fbSession.getAccessToken());
+      response.put("expireTimeMs", fbSession.getExpirationDate().getTime());
+      response.put("applicationId", fbSession.getApplicationId());
+      response.put("permissions", fbSession.getPermissions());
+    } else {
+      response.put("status", "disconnected");
     }
+    return new JSONObject(response);
+  }
 
-    public JSONObject getResponse() {
-    	String response;
-    	if (facebook.isSessionValid()) {
-    		long expiresTimeInterval = facebook.getAccessExpires() - System.currentTimeMillis();
-    		long expiresIn = (expiresTimeInterval > 0) ? expiresTimeInterval : 0;
-    		response = "{"+
-            "\"status\": \"connected\","+
-            "\"authResponse\": {"+
-              "\"accessToken\": \""+facebook.getAccessToken()+"\","+
-              "\"expiresIn\": \""+expiresIn+"\","+
-              "\"session_key\": true,"+
-              "\"sig\": \"...\","+
-              "\"userId\": \""+this.userId+"\""+
-            "}"+
-          "}";
-    	} else {
-    		response = "{"+
-            "\"status\": \"unknown\""+
-          "}";
-    	}
-
-        try {
-            return new JSONObject(response);
-        } catch (JSONException e) {
-           
-            e.printStackTrace();
-        }
-        return new JSONObject();
-    }
-    
-    class UIDialogListener implements DialogListener {
-   	 final ConnectPlugin fba;
-
-		public UIDialogListener(ConnectPlugin fba){
-			super();
-			this.fba = fba;
-		}
-
-		public void onComplete(Bundle values) {
-			//  Handle a successful dialog
-			Log.d(TAG,values.toString());
-			this.fba.success(new PluginResult(PluginResult.Status.OK), this.fba.callbackId);
-		}
-
-		public void onFacebookError(FacebookError e) {
-           Log.d(TAG, "facebook error");
-           this.fba.error("Facebook error: " + e.getMessage(), callbackId);
-       }
-
-       public void onError(DialogError e) {
-           Log.d(TAG, "other error");
-           this.fba.error("Dialog error: " + e.getMessage(), this.fba.callbackId);
-       }
-
-       public void onCancel() {
-           Log.d(TAG, "cancel");
-           this.fba.error("Cancelled", this.fba.callbackId);
-       }
-	}
-
-    class AuthorizeListener implements DialogListener {
-        final ConnectPlugin fba;
-
-        public AuthorizeListener(ConnectPlugin fba){
-            super();
-            this.fba = fba;
-        }
-
-        public void onComplete(Bundle values) {
-            //  Handle a successful login
-
-            String token = this.fba.facebook.getAccessToken();
-            long token_expires = this.fba.facebook.getAccessExpires();
-            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this.fba.cordova.getActivity());
-            prefs.edit().putLong("access_expires", token_expires).commit();
-            prefs.edit().putString("access_token", token).commit();
-
-            Log.d(TAG, "authorized");
-
-            Thread t = new Thread(new Runnable() {
-                public void run() {
-                    try {
-                        JSONObject o = new JSONObject(fba.facebook.request("/me"));
-                        fba.userId = o.getString("id");
-                        fba.success(getResponse(), fba.callbackId);
-                    } catch (MalformedURLException e) {
-                        // TODO Auto-generated catch block
-                        e.printStackTrace();
-                    } catch (IOException e) {
-                        // TODO Auto-generated catch block
-                        e.printStackTrace();
-                    } catch (JSONException e) {
-                        // TODO Auto-generated catch block
-                        e.printStackTrace();
-                    }
-                }
-            });
-            t.start();
-        }
-
-        public void onFacebookError(FacebookError e) {
-            Log.d(TAG, "facebook error");
-            this.fba.error("Facebook error: " + e.getMessage(), callbackId);
-        }
-
-        public void onError(DialogError e) {
-            Log.d(TAG, "other error");
-            this.fba.error("Dialog error: " + e.getMessage(), this.fba.callbackId);
-        }
-
-        public void onCancel() {
-            Log.d(TAG, "cancel");
-            this.fba.error("Cancelled", this.fba.callbackId);
-        }
-    }
+  @Override
+  public void onActivityResult(int requestCode, int resultCode, Intent intent) {
+    super.onActivityResult(requestCode, resultCode, intent);
+    Session activeSession = Session.getActiveSession();
+    activeSession.onActivityResult(cordova.getActivity(), requestCode, resultCode, intent);
+  }
 }


### PR DESCRIPTION
These are the differences with the original class:
- the "init" method is needed no more since new APIs get application id from app_id string property (in strings.xml)
- added a "me" method to get info about the current logged user
- there is yet no support to ask for extended permissions as I don't understand how they are supposed to be passed on current api
- there is no "showdialog" method because I don't know what it's supposed to do and how to use it. If still useful this must be copied/rewritten as well

I've used the plugin directly, without the JS wrapper, so more testing is needed, and maybe some modifications, too.
