### PR TITLE
fixed reference to facebook-js-sdk.js in example

### DIFF
--- a/example/HackBook/index.html
+++ b/example/HackBook/index.html
@@ -312,7 +312,7 @@
   <!-- cordova facebook plugin -->
   <script src="cdv-plugin-fb-connect.js"></script>
   <!-- facebook js sdk -->
-  <script src="facebook_js_sdk.js"></script> 
+  <script src="facebook-js-sdk.js"></script> 
   
   <!--<script src="js/_config.js"></script>-->
   <script src="js/ui.js"></script>


### PR DESCRIPTION
The filename is actually facebook-js-sdk.js, not facebook_js_sdk.js. This change makes the "manual install instructions" correct.
