### PR TITLE
use objectForKey for id on instances of FBGraphUser to avoid non-public ...

### DIFF
--- a/src/ios/FacebookConnectPlugin.m
+++ b/src/ios/FacebookConnectPlugin.m
@@ -67,7 +67,7 @@
                     [FBRequestConnection startForMeWithCompletionHandler:
                      ^(FBRequestConnection *connection, id <FBGraphUser>user, NSError *error) {
                          if (!error) {
-                             self.userid = user.id;
+                             self.userid = [user objectForKey:@"id"];
                              // Send the plugin result. Wait for a successful fetch of user info.
                              CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
                                                                            messageAsDictionary:[self responseObject]];


### PR DESCRIPTION
...selector warning on iOS
