### PR TITLE
iOS CDV callback on user cancel during login - added CDV callback to switch branch

### DIFF
--- a/src/ios/FacebookConnectPlugin.m
+++ b/src/ios/FacebookConnectPlugin.m
@@ -71,8 +71,13 @@
             break;
         case FBSessionStateClosed:
         case FBSessionStateClosedLoginFailed:
-            [FBSession.activeSession closeAndClearTokenInformation];
-            self.userid = @"";
+                {
+                [FBSession.activeSession closeAndClearTokenInformation];
+                self.userid = @"";
+                CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                              messageAsDictionary:[self responseObject]];
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:self.loginCallbackId];
+                }
             break;
         default:
             break;


### PR DESCRIPTION
When user cancels native auth/approval dialog on iOS no result is passed back to JS context (specifically Facebook-js-sdk.js line 5117 case permissions.oauth ERROR CB never called). Added ERROR callback on native side in state switch for FBSessionStateClosedLoginFailed and error is now passed back to JS. P.S Thanks for the absolutely awesome piece of work on this library - opens up a world of possibilities! 
