### PR TITLE
Reference of config.xml fixed for android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -21,14 +21,6 @@
     <asset src="www/cdv-plugin-fb-connect.js" target="cdv-plugin-fb-connect.js" />
     <asset src="www/facebook-js-sdk.js" target="facebook-js-sdk.js" />
     
-    <config-file target="config.xml" parent="/*">
-	    <access origin="https://m.facebook.com" />
-	    <access origin="https://graph.facebook.com" />
-	    <access origin="https://api.facebook.com" />
-	    <access origin="https://*.fbcdn.net" />
-	    <access origin="https://*.akamaihd.net" />
-    </config-file>
-    
     <preference name="APP_ID" />
 	<preference name="APP_NAME" />
     
@@ -51,6 +43,11 @@
             <feature name="FacebookConnectPlugin">
                 <param name="android-package" value="org.apache.cordova.facebook.ConnectPlugin" />
             </feature>
+            <access origin="https://m.facebook.com" />
+	    <access origin="https://graph.facebook.com" />
+	    <access origin="https://api.facebook.com" />
+	    <access origin="https://*.fbcdn.net" />
+	    <access origin="https://*.akamaihd.net" />
         </config-file>
         
         <source-file src="src/android/facebook/res/values/facebookconnect.xml" target-dir="res/values" />
@@ -80,6 +77,11 @@
 			    <param name="onload" value="true" />
 		    </feature>
 		    <plugin name="FacebookConnectPlugin" value="FacebookConnectPlugin"/>
+		    <access origin="https://m.facebook.com" />
+	    	    <access origin="https://graph.facebook.com" />
+	    	    <access origin="https://api.facebook.com" />
+	    	    <access origin="https://*.fbcdn.net" />
+	    	    <access origin="https://*.akamaihd.net" />
 	    </config-file>
 
         <header-file src="src/ios/FacebookConnectPlugin.h" />


### PR DESCRIPTION
If I used this plugin together with other plugins, the other plugins stopped to work on android. I checked the android's plugin.xml file and found that only this plugin's <feature>-Element was added.
This fix works for me, I don't know about side-effects, so use with caution - I just posted it because it may be helpful to others.
