### PR TITLE
Fix config.xml path in Android platform

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -47,7 +47,7 @@
     <!-- android -->
     <platform name="android">
         
-        <config-file target="config.xml" parent="/*">
+        <config-file target="res/xml/config.xml" parent="/*">
             <feature name="FacebookConnectPlugin">
                 <param name="android-package" value="org.apache.cordova.facebook.ConnectPlugin" />
             </feature>


### PR DESCRIPTION
Incorrect path was making other plugins not to be declared for Android platform.
