### PR TITLE
check loginCallbackId exists before pluginResult call

### DIFF
--- a/platforms/ios/HelloCordova/Plugins/com.phonegap.plugins.facebookconnect/FacebookConnectPlugin.m
+++ b/platforms/ios/HelloCordova/Plugins/com.phonegap.plugins.facebookconnect/FacebookConnectPlugin.m
@@ -73,8 +73,8 @@
                              self.userid = user.id;
                              
                              // Send the plugin result. Wait for a successful fetch of user info.
-                             if(self.loginCallbackId) {
-                                CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                             if (self.loginCallbackId) {
+                                CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
                                                                            messageAsDictionary:[self responseObject]];
                                 [self.commandDelegate sendPluginResult:pluginResult callbackId:self.loginCallbackId];
                              }
@@ -82,11 +82,11 @@
                              self.userid = @"";
                          }
                      }];
-                }else {
+                } else {
                     // Don't get user's info but trigger success callback
                     // Send the plugin result. Wait for a successful fetch of user info.
-                    if(self.loginCallbackId) {
-                        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK 
+                    if (self.loginCallbackId) {
+                        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK 
                                                                 messageAsDictionary:[self responseObject]];
                         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.loginCallbackId];
                     }


### PR DESCRIPTION
We make sure that loginCallbackId exists before calling it. When it's not set, it triggers the exception referenced in issue #507
