### PR TITLE
Removing the window title of the background

### DIFF
--- a/platforms/android/FacebookLib/src/com/facebook/LoginActivity.java
+++ b/platforms/android/FacebookLib/src/com/facebook/LoginActivity.java
@@ -54,6 +54,7 @@ public class LoginActivity extends Activity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        requestWindowFeature(Window.FEATURE_NO_TITLE);
         setContentView(R.layout.com_facebook_login_activity_layout);
 
         if (savedInstanceState != null) {


### PR DESCRIPTION
The background activity is a black canvas with a style that probably will not match the app. Adding the "No Title Bar" it will just be a full black canvas looking like a shadow, not a workaround.
