### PR TITLE
login function callbacks are not called

### DIFF
--- a/platforms/ios/HelloCordova/Plugins/com.phonegap.plugins.facebookconnect/FacebookConnectPlugin.m
+++ b/platforms/ios/HelloCordova/Plugins/com.phonegap.plugins.facebookconnect/FacebookConnectPlugin.m
@@ -126,6 +126,7 @@
         } else if (error.fberrorCategory == FBErrorCategoryUserCancelled) {
             // The user has cancelled a login. You can inspect the error
             // for more context. In the plugin, we will simply ignore it.
+            alertMessage = @"Permission denied.";
         } else {
             // For simplicity, this sample treats other errors blindly.
             alertMessage = @"Error. Please try again later.";


### PR DESCRIPTION
When calling `login` method with `public_profile` neither `success` or `failure` callback are called when in iOS and native iOS facebook integration account is signed out.

I have been investigation this issue and it is because on my app page `public_profile` gives an error (see below raw request/response). I **think** this might be a facebook issue, but nonetheless the login function **must** call the callback.

**Workaround** By switching from `public_profile` to `basic_info` (which as far as I know was inferred automatically before, but it isn't now) everything works.

By reading the source on [FacebookConnectPlugin.m:255](https://github.com/Wizcorp/phonegap-facebook-plugin/blob/master/platforms/ios/HelloCordova/Plugins/com.phonegap.plugins.facebookconnect/FacebookConnectPlugin.m#L255) the `FBSession::openActiveSessionWithReadPersmissions]` is called which in turn will call back `sessionStateChanged` with `state=FBSessionStateClosedLoginFailed` which has the error [SystemLoginCancelled](https://github.com/facebook/facebook-ios-sdk/blob/master/src/Core/FBError.m#L34). (see the log below)

**Note** I have created a [facebook bug ticket](https://developers.facebook.com/bugs/679190988830802/) to address this issue.
# Related Issues
- #512
- #489
- #554
- #474 
- #430
- #368
# API Call Request/Response
#### Request

```
GET /method/permissions.getiosdescription?access_token=CENSORED&format=json&locale=en&permissions=public_profile&write_privacy=
```
#### Response

```
{
    "error_code": 100,
    "error_msg": "invalid permissions: public_profile",
    "request_args": [{
        "key": "method",
        "value": "permissions.getiosdescription"
    }, {
        "key": "access_token",
        "value": "CENSORED"
    }, {
        "key": "format",
        "value": "json"
    }, {
        "key": "locale",
        "value": "en"
    }, {
        "key": "permissions",
        "value": "public_profile"
    }, {
        "key": "write_privacy",
        "value": ""
    }]
}
```
# FBError details

```
Error Domain=com.facebook.sdk Code=2 "The operation couldn’t be completed. (com.facebook.sdk error 2.)" UserInfo=0x10ad15ab0 
{
  com.facebook.sdk:ErrorLoginFailedReason=com.facebook.sdk:SystemLoginCancelled, 
  com.facebook.sdk:ErrorInnerErrorKey=Error Domain=com.apple.accounts Code=7 "The operation couldn’t be completed. (com.apple.accounts error 7.)", 
  com.facebook.sdk:ErrorSessionKey=<FBSession: 0x10ad3e060, 
  state: FBSessionStateClosedLoginFailed, 
  loginHandler: 0x0, 
  appID: 891837340830467, 
  urlSchemeSuffix: , 
  tokenCachingStrategy:<FBSessionTokenCachingStrategy: 0x10ba3dd20>, 
  expirationDate: (null), 
  refreshDate: (null), 
  attemptedRefreshDate: 0001-12-30 00:00:00 +0000, 
  permissions:(null)>
}
```
