### PR TITLE
fixed null pointer exception in getLoginStatus

### DIFF
--- a/platforms/android/src/org/apache/cordova/facebook/ConnectPlugin.java
+++ b/platforms/android/src/org/apache/cordova/facebook/ConnectPlugin.java
@@ -202,7 +202,12 @@ public class ConnectPlugin extends CordovaPlugin {
 			}
 			return true;
 		} else if (action.equals("getLoginStatus")) {
-			callbackContext.success(Session.getActiveSession().getState().toString());
+			Session session = Session.getActiveSession();
+			if (session != null) {
+				callbackContext.success(Session.getActiveSession().getState().toString());
+			} else {
+				callbackContext.error("Session not open.");
+			}
 			return true;
 		} else if (action.equals("getAccessToken")) {
 			Session session = Session.getActiveSession();


### PR DESCRIPTION
added a check for a valid session to getLoginStatus since. When there was no session it threw a null pointer exception.
