### PR TITLE
Only load the facebook SDK if it has not yet been loaded

### DIFF
--- a/www/js/facebookConnectPlugin.js
+++ b/www/js/facebookConnectPlugin.js
@@ -167,11 +167,13 @@ if (!window.cordova) {
     
     // Bake in the JS SDK
     (function () {
-        console.log("launching FB SDK")
-        var e = document.createElement('script');
-        e.src = document.location.protocol + '//connect.facebook.net/en_US/sdk.js';
-        e.async = true;
-        document.getElementById('fb-root').appendChild(e);
+        if (!window.FB) {
+            console.log("launching FB SDK")
+            var e = document.createElement('script');
+            e.src = document.location.protocol + '//connect.facebook.net/en_US/sdk.js';
+            e.async = true;
+            document.getElementById('fb-root').appendChild(e);
+        }
     }());
 
 }


### PR DESCRIPTION
I'm including the facebook sdk locally for optimization purposes.  This is to prevent the sdk from being needlessly re-requested in such cases.
