### PR TITLE
Fixed incorrect parameter format in login().

### DIFF
--- a/www/phonegap/plugin/facebookConnectPlugin/facebookConnectPlugin.js
+++ b/www/phonegap/plugin/facebookConnectPlugin/facebookConnectPlugin.js
@@ -77,7 +77,7 @@ if (!window.cordova) {
         },
 
         login: function (permissions, s, f) {
-            cordova.exec(s, f, "FacebookConnectPlugin", "login", permissions);
+            cordova.exec(s, f, "FacebookConnectPlugin", "login", [permissions]);
         },
 
         logEvent: function(name, params, valueToSum, s, f) {


### PR DESCRIPTION
`facebookConnectPlugin.login()` had an incorrect parameter `permissions` passed in without being wrapped in an array. It prevents `ConnectPlugin.execute()` from being called.
