### PR TITLE
Use href param instead of link for share dialog

### DIFF
--- a/www/js/facebookConnectPlugin.js
+++ b/www/js/facebookConnectPlugin.js
@@ -40,8 +40,8 @@ if (!window.cordova) {
             if (!options.description) {
                 options.description = "";
             }
-            if (!options.link) {
-                options.link = "";
+            if (!options.href) {
+                options.href = "";
             }
             if (!options.picture) {
                 options.picture = "";
@@ -57,7 +57,7 @@ if (!window.cordova) {
                     description: (
                         options.description
                     ),
-                    link: options.link,
+                    href: options.href,
                     picture: options.picture
                 },
                 function (response) {


### PR DESCRIPTION
The correct parameter for all versions of FB API is `href` not `link`.

See https://developers.facebook.com/docs/javascript/reference/FB.ui
