### PR TITLE
Replace copying of the FacebookSDK library with a framework reference.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -56,8 +56,7 @@
             <activity android:label="@string/fb_app_name" android:name="com.facebook.LoginActivity"></activity>
         </config-file>
 
-        <!-- copy Facebook Lib project -->
-        <source-file src="platforms/android/FacebookLib" target-dir="./" />
+        <framework src="platforms/android/FacebookLib" custom="true" />
         
         <!-- cordova plugin src files -->
         <source-file src="platforms/android/src/org/apache/cordova/facebook/ConnectPlugin.java" target-dir="src/org/apache/cordova/facebook" />


### PR DESCRIPTION
This obsoletes the need to manually add it in the Android project as it can be done by [plugman](https://github.com/apache/cordova-docs/blob/master/docs/en/edge/plugin_ref/spec.md#framework-element)
