### PR TITLE
[Android] Use native Share Dialog

### DIFF
--- a/platforms/android/src/org/apache/cordova/facebook/ConnectPlugin.java
+++ b/platforms/android/src/org/apache/cordova/facebook/ConnectPlugin.java
@@ -150,7 +150,11 @@ public class ConnectPlugin extends CordovaPlugin {
                     });
                 }
                 else {
-                    Session.getActiveSession().onActivityResult(cordova.getActivity(), requestCode, resultCode, intent);
+                    Session session = Session.getActiveSession();
+
+                    if (session != null && session.isOpened()) {
+                            session.onActivityResult(cordova.getActivity(), requestCode, resultCode, intent);
+                    }
                 }
                 trackingPendingCall = false;
 	}


### PR DESCRIPTION
Use Native Share Dialog and fallback to Feeds Dialog when it is not available (as recommended by Facebook: https://developers.facebook.com/docs/android/share#linkfeed)

Related to issue: https://github.com/Wizcorp/phonegap-facebook-plugin/issues/681
