### PR TITLE
Replace copying of the FacebookSDK library with a framework reference.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,8 @@
     
     <engines>
     	<!-- Requires > 3.3.* because of the custom Framework tag for iOS [CB-5238] -->
-    	<engine name="cordova" version=">=3.3.0" />
+    	<!-- Requires > 3.5.0 because of the custom Framework tag for Android [CB-6698] -->
+    	<engine name="cordova" version=">=3.5.0" />
     </engines>
     
     <!-- JavaScript interface -->


### PR DESCRIPTION
This obsoletes the need to manually add it in the Android project as it can be done by [plugman](https://github.com/apache/cordova-docs/blob/master/docs/en/edge/plugin_ref/spec.md#framework-element)
