### PR TITLE
If userID is null on reactivated session update it by making a synchronous graph api request to me endpoint

### DIFF
--- a/platforms/android/src/org/apache/cordova/facebook/ConnectPlugin.java
+++ b/platforms/android/src/org/apache/cordova/facebook/ConnectPlugin.java
@@ -639,6 +639,13 @@ public class ConnectPlugin extends CordovaPlugin {
 			Date today = new Date();
 			long expiresTimeInterval = (session.getExpirationDate().getTime() - today.getTime()) / 1000L;
 			long expiresIn = (expiresTimeInterval > 0) ? expiresTimeInterval : 0;
+
+			if (userID == null) {
+				Request request = Request.newGraphPathRequest(session, "me", null);
+				Response meResponse = Request.executeAndWait(request);
+				userID = meResponse.getGraphObject().getProperty("id").toString();
+			}
+
 			response = "{"
 				+ "\"status\": \"connected\","
 				+ "\"authResponse\": {"


### PR DESCRIPTION
I also experienced issue #662 when calling getLoginStatus on reactivated user session
