### PR TITLE
Fix FacebookLib directory

### DIFF
--- a/platforms/android/README.md
+++ b/platforms/android/README.md
@@ -56,13 +56,13 @@ Follow the steps below:
 	
 	android update project --subprojects --path "platforms/android" --target android-19 --library "CordovaLib"
 	
-	android update project --subprojects --path "platforms/android" --target android-19 --library "FacebookLib"
+	android update project --subprojects --path "platforms/android" --target android-19 --library "com.phonegap.plugins.facebookconnect/FacebookLib"
 	
 	cd platforms/android/
 	
 	ant clean
 	
-	cd FacebookLib
+	cd com.phonegap.plugins.facebookconnect/FacebookLib
 	
 	ant clean
 	


### PR DESCRIPTION
The FacebookLib directory appears to now be at `platforms/android/com.phonegap.plugins.facebookconnect/FacebookLib` rather than `platforms/android/FacebookLib`.
