### PR TITLE
Friction less requests

### DIFF
--- a/platforms/android/src/org/apache/cordova/facebook/ConnectPlugin.java
+++ b/platforms/android/src/org/apache/cordova/facebook/ConnectPlugin.java
@@ -392,6 +392,7 @@ public class ConnectPlugin extends CordovaPlugin {
 				cordova.getActivity().runOnUiThread(runnable);
 			} else if (this.method.equalsIgnoreCase("apprequests")) {
 				Runnable runnable = new Runnable() {
+					paramBundle.putString("frictionless", "1");
 					public void run() {
 						WebDialog requestsDialog = (new WebDialog.RequestsDialogBuilder(me.cordova.getActivity(), Session.getActiveSession(), paramBundle)).setOnCompleteListener(dialogCallback)
 							.build();

--- a/platforms/ios/HelloCordova/Plugins/com.phonegap.plugins.facebookconnect/FacebookConnectPlugin.m
+++ b/platforms/ios/HelloCordova/Plugins/com.phonegap.plugins.facebookconnect/FacebookConnectPlugin.m
@@ -388,6 +388,7 @@
         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.dialogCallbackId];
     } else {
         // Show the web dialog
+        [params setObject: @"1" forKey:@"frictionless"];
         [FBWebDialogs
          presentDialogModallyWithSession:FBSession.activeSession
          dialog:method parameters:params

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="com.phonegap.plugins.facebookconnect"
-    version="0.8.0">
+    version="0.8.1">
 
     <name>Facebook Connect</name>
     


### PR DESCRIPTION
it just needs a parameter
On javascript sdk, this parameter is set on FB.init, I think on native it should be in config.xml, like appid
(I'm new on iOS and android so I dont really know how to correctly handle this initialization parameter)

test it from javascript console :
```
facebookConnectPlugin.showDialog(
    {
        method:"apprequests",
        to:[XXX], // friend facebook id
        message:"testing requests"
    },
    function(response){
        console.log(response);
    }
);
```

Without friction less facebook popup on ly propose to send or cancel, with friction less you have a checkbox allowing to not asking confirmation anymore for your friend(s)