### PR TITLE
Fixes NullPointer on login

### DIFF
--- a/platforms/android/src/org/apache/cordova/facebook/ConnectPlugin.java
+++ b/platforms/android/src/org/apache/cordova/facebook/ConnectPlugin.java
@@ -543,6 +543,12 @@ public class ConnectPlugin extends CordovaPlugin {
 				public void onCompleted(GraphUser user, Response response) {
 					// Create a new result with response data
 					if (loginContext != null) {
+						
+						if ( response.getError() != null ) {
+						    loginContext.error( getResponse() );
+						    return;
+						}
+					
 						GraphObject graphObject = response.getGraphObject();
 						Log.d(TAG, "returning login object " + graphObject.getInnerJSONObject().toString());
 						userID = user.getId();


### PR DESCRIPTION
Fixed: calling the error callback when the login fails.

Related issue:
https://github.com/Wizcorp/phonegap-facebook-plugin/issues/579
