### PR TITLE
Update README.md text regarding broken symlinks in FacebookSDK.framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Facebook plugin for [Apache Cordova](http://incubator.apache.org/cordova/) a
 
 ## << --- Cordova Registry Warning [iOS]
 
-****Installing this plugin directly from Cordova Registry results in Xcode using a broken `Facebook.framework`, this is because the current publish procedure to NPM breaks symlinks [CB-6092](https://issues.apache.org/jira/browse/CB-6092). Please re-add facebook.framework to Xcode.****
+****Installing this plugin directly from Cordova Registry results in Xcode using a broken `FacebookSDK.framework`, this is because the current publish procedure to NPM breaks symlinks [CB-6092](https://issues.apache.org/jira/browse/CB-6092). Please install the plugin through a locally cloned copy or re-add the `FacebookSDK.framework` to Xcode after installation.****
 
 ## ------------------------------------------ >>
 

--- a/platforms/android/README.md
+++ b/platforms/android/README.md
@@ -19,15 +19,16 @@ For Android sample app remember to configure the project with your FB app id in 
 
 This plugin requires [Cordova CLI](http://cordova.apache.org/docs/en/3.5.0/guide_cli_index.md.html).
 
-To install the plugin in your app, execute the following (replace variables where necessary)...
+To install the plugin in your app, execute the following (replace variables where necessary):
+```sh
+# Create initial Cordova app
+$ cordova create myApp
+$ cd myApp/
+$ cordova platform add android
 
-	cordova create myApp
-
-	cd myApp/
-
-	cordova platform add android
-
-	cordova -d plugin add /Users/your/path/here/phonegap-facebook-plugin --variable APP_ID="123456789" --variable APP_NAME="myApplication"
+# Remember to replace APP_ID and APP_NAME variables
+$ cordova -d plugin add /path/to/cloned/phonegap-facebook-plugin --variable APP_ID="123456789" --variable APP_NAME="myApplication"
+```
 
 ## Setup with Eclipse
 

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -19,13 +19,19 @@ Currently these are set as defaults, so please change:
 
 This plugin requires [Cordova CLI](http://cordova.apache.org/docs/en/3.5.0/guide_cli_index.md.html).
 
-To install the plugin in your app, execute the following (replace variables where necessary)...
+Installing this plugin directly from Cordova Registry currently breaks the symlinks in `FacebookSDK.framework` [CB-6092](https://issues.apache.org/jira/browse/CB-6092). Easiest solution for now is to just `git clone` this project and install it with *Cordova CLI* using the local clone.
+```sh
+$ git clone https://github.com/Wizcorp/phonegap-facebook-plugin.git
+```
 
+To install the plugin in your app, execute the following (replace variables where necessary):
+```sh
+# Create initial Cordova app
+$ cordova create myApp
+$ cd myApp/
+$ cordova platform add ios
 
-	cordova create myApp
-
-	cd myApp/
-
-	cordova platform add ios
-
-	cordova -d plugin add /Users/your/path/here/phonegap-facebook-plugin --variable APP_ID="123456789" --variable APP_NAME="myApplication"
+# The path you cloned the plugin to earlier
+# Remember to replace APP_ID and APP_NAME variables
+$ cordova -d plugin add /path/to/cloned/phonegap-facebook-plugin --variable APP_ID="123456789" --variable APP_NAME="myApplication"
+```


### PR DESCRIPTION
I agree with @georgir https://github.com/Wizcorp/phonegap-facebook-plugin/issues/545#issuecomment-59198438 that the current README.md isn't very accurate regarding the installation and broken symlinks.

Attempted to add some better explanatory text, atleast until the plugin is perhaps published as a tar-ball as suggested in [CB-6092](https://issues.apache.org/jira/browse/CB-6092).
