### PR TITLE
FIX browser check -- causing errors

### DIFF
--- a/facebookConnectPlugin.js
+++ b/facebookConnectPlugin.js
@@ -9,7 +9,7 @@
  *
  */
 
-if (cordova.platformId == "browser") {
+if (!window.cordova || cordova.platformId == "browser") {
 
     var facebookConnectPlugin = {
 


### PR DESCRIPTION
I don't see how this works since cordova is **always undefined** in the browser environment.

By adding `if (!window.cordova)`, it checks to see if cordova is available and if not continues into the browser API (rather than native cordova API).

I've had many issues in [ng-cordova](https://github.com/driftyco/ng-cordova/), specifically issue [#446](https://github.com/driftyco/ng-cordova/issues/446)