### PR TITLE
Fixed issue #887 by listening to events

### DIFF
--- a/facebookConnectPlugin.js
+++ b/facebookConnectPlugin.js
@@ -159,18 +159,24 @@ if (cordova.platformId == "browser") {
     
     // Bake in the JS SDK
     (function () {
+        // Retrieve the root element to append the script tags to
+        var root = document.getElementById('fb-root') || document.getElementsByTagName('body')[0];
+
         if (!window.FB) {
             console.log("launching FB SDK");
             var e = document.createElement('script');
-            e.src = document.location.protocol + '//connect.facebook.net/en_US/sdk.js';
             e.async = true;
-            document.getElementById('fb-root').appendChild(e);
-            if (!window.FB) {
-                // Probably not on server, use the sample sdk
-                e.src = 'phonegap/plugin/facebookConnectPlugin/fbsdk.js';
-                document.getElementById('fb-root').appendChild(e);
-                console.log("Attempt local load: ", e);
-            }
+            e.src = document.location.protocol + '//connect.facebook.net/en_US/sdk.js';
+            e.onerror = onSDKError;
+
+            root.appendChild(e);
+        }
+
+        /**
+         * If an error occurs, show it in the console.
+         */
+        function onSDKError(e) {
+            console.error('Could not load the Facebook SDK.', e);
         }
     }());
 

--- a/platforms/browser/www/phonegap/plugin/facebookConnectPlugin/facebookConnectPlugin.js
+++ b/platforms/browser/www/phonegap/plugin/facebookConnectPlugin/facebookConnectPlugin.js
@@ -161,7 +161,7 @@ cordova.define("com.phonegap.plugins.facebookconnect.FacebookConnectPlugin", fun
         
         // Bake in the JS SDK
         (function () {
-            // Retrieve the root element to append the script tags to. Use the body if no fb-root was found
+            // Retrieve the root element to append the script tags to
             var root = document.getElementById('fb-root') || document.getElementsByTagName('body')[0];
 
             if (!window.FB) {
@@ -169,25 +169,16 @@ cordova.define("com.phonegap.plugins.facebookconnect.FacebookConnectPlugin", fun
                 var e = document.createElement('script');
                 e.async = true;
                 e.src = document.location.protocol + '//connect.facebook.net/en_US/sdk.js';
-                e.onload = e.onreadystatechange = e.onerror = loadLocalSDK;
+                e.onerror = onSDKError;
 
                 root.appendChild(e);
             }
 
             /**
-             * If something happens when loading the remote script, then check if
-             * window.FB exists, if not, load the local script.
+             * If an error occurs, show it in the console.
              */
-            function loadLocalSDK() {
-                if (!window.FB) {
-                    var e = document.createElement('script');
-                    e.async = true;
-                    e.src = 'phonegap/plugin/facebookConnectPlugin/fbsdk.js';
-
-                    root.appendChild(e);
-
-                    console.log("Attempt local load: ", e);
-                }
+            function onSDKError(e) {
+                console.error('Could not load the Facebook SDK.', e);
             }
         }());
 

--- a/platforms/browser/www/phonegap/plugin/facebookConnectPlugin/facebookConnectPlugin.js
+++ b/platforms/browser/www/phonegap/plugin/facebookConnectPlugin/facebookConnectPlugin.js
@@ -161,16 +161,31 @@ cordova.define("com.phonegap.plugins.facebookconnect.FacebookConnectPlugin", fun
         
         // Bake in the JS SDK
         (function () {
+            // Retrieve the root element to append the script tags to. Use the body if no fb-root was found
+            var root = document.getElementById('fb-root') || document.getElementsByTagName('body')[0];
+
             if (!window.FB) {
                 console.log("launching FB SDK");
                 var e = document.createElement('script');
-                e.src = document.location.protocol + '//connect.facebook.net/en_US/sdk.js';
                 e.async = true;
-                document.getElementById('fb-root').appendChild(e);
+                e.src = document.location.protocol + '//connect.facebook.net/en_US/sdk.js';
+                e.onload = e.onreadystatechange = e.onerror = loadLocalSDK;
+
+                root.appendChild(e);
+            }
+
+            /**
+             * If something happens when loading the remote script, then check if
+             * window.FB exists, if not, load the local script.
+             */
+            function loadLocalSDK() {
                 if (!window.FB) {
-                    // Probably not on server, use the sample sdk
+                    var e = document.createElement('script');
+                    e.async = true;
                     e.src = 'phonegap/plugin/facebookConnectPlugin/fbsdk.js';
-                    document.getElementById('fb-root').appendChild(e);
+
+                    root.appendChild(e);
+
                     console.log("Attempt local load: ", e);
                 }
             }


### PR DESCRIPTION
It's not necessary anymore to add the <div id="fb-root"></div> tag. If that tag doens't exist in the DOM, it will pick the body to append the script tags to.

First it tries to load the remote SDK from the FB servers. Instead of instantly checking if window.FB exists, it will wait for the events to fire. This way, we now for sure that the script was or wasn't loaded properly. Then we can safely check if window.FB exists, if it still doesn't exist we create a new script tag with the local SDK source file. The reason why we can't use the same script tag as before is because on some browsers, it looks like the script is not loaded when dynamically changing the src attribute for the second time.