### PR TITLE
Fixed library breaking when viewing from file://

### DIFF
--- a/facebookConnectPlugin.js
+++ b/facebookConnectPlugin.js
@@ -162,7 +162,7 @@ if (cordova.platformId == "browser") {
         if (!window.FB) {
             console.log("launching FB SDK");
             var e = document.createElement('script');
-            e.src = document.location.protocol + '//connect.facebook.net/en_US/sdk.js';
+            e.src = (document.location.protocol === 'https:' ? 'https:' : 'http:') + '//connect.facebook.net/en_US/sdk.js';
             e.async = true;
             document.getElementById('fb-root').appendChild(e);
             if (!window.FB) {


### PR DESCRIPTION
When testing this in a file:// protocol, it breaks because the protocol is not compatible with the way the code is currently written. This use case happens when emulating a browser through ionic.