### PR TITLE
[iOS] Return a more comprehensive error message instead of "Please try again later"

### DIFF
--- a/platforms/ios/HelloCordova/Plugins/com.phonegap.plugins.facebookconnect/FacebookConnectPlugin.m
+++ b/platforms/ios/HelloCordova/Plugins/com.phonegap.plugins.facebookconnect/FacebookConnectPlugin.m
@@ -140,7 +140,7 @@
             alertMessage = @"Permission denied.";
         } else {
             // For simplicity, this sample treats other errors blindly.
-            alertMessage = @"Error. Please try again later.";
+            alertMessage = [error localizedDescription];
         }
         
         if (alertMessage && self.loginCallbackId) {


### PR DESCRIPTION
I have seen a lot of people getting confused about the `Error. Please try again later` error message. We should, in the generic cases, default to the `localizedDescription`, as it provides much more insights about what might be actually going wrong.

This is the error message you will currently see if you commit the basic error of adding a typo to your bundle id in the facebook settings:
![screen shot 2015-03-20 at 2 48 58 am](https://cloud.githubusercontent.com/assets/445831/6746707/bc54304a-ceab-11e4-8f0f-f4f4d9ba31b6.png)



Contrast that with the error message you would get after this change:
![screen shot 2015-03-20 at 2 46 21 am](https://cloud.githubusercontent.com/assets/445831/6746680/54136d34-ceab-11e4-8e7b-60ca78eb7143.png)
