### PR TITLE
Fixed command.argument checking in iOS logPurchase

### DIFF
--- a/platforms/ios/HelloCordova/Plugins/com.phonegap.plugins.facebookconnect/FacebookConnectPlugin.m
+++ b/platforms/ios/HelloCordova/Plugins/com.phonegap.plugins.facebookconnect/FacebookConnectPlugin.m
@@ -235,7 +235,7 @@
      there is a helper method that explicitly takes a currency indicator.
      */
     CDVPluginResult *res;
-    if (!command.arguments == 2) {
+    if ([command.arguments count] != 2) {
         res = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid arguments"];
         [self.commandDelegate sendPluginResult:res callbackId:command.callbackId];
         return;


### PR DESCRIPTION
Without this logPurchase won't ever work as `!command.arguments == 2` will always be false. (As a bonus, this also gets rid of Xcode's warning regarding that case.)