### PR TITLE
Makes Gradle to work correct; also fixes Ant

### DIFF
--- a/platforms/android/FacebookLib/build-extras.gradle
+++ b/platforms/android/FacebookLib/build-extras.gradle
@@ -1,0 +1,14 @@
+repositories {
+    mavenCentral()
+}
+
+apply plugin: 'android-library'
+
+// remove default compile dependencies which could include duplicate jars from 'FacebookLib/libs' folder
+configurations.compile.dependencies.clear()
+
+// add required dependencies
+dependencies {
+    compile 'com.android.support:support-v4:[20,21)'
+    compile 'com.parse.bolts:bolts-android:1.1.2'
+}

--- a/platforms/android/FacebookLib/custom_rules.xml
+++ b/platforms/android/FacebookLib/custom_rules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
     <target name="-post-compile">
-        <copy todir="bin">
+        <copy todir="bin" failonerror="false">
             <fileset dir="ant-build"/>
         </copy>
     </target>


### PR DESCRIPTION
1. `build.gradle` is automatically overwritten by default one (special Cordova logic) so no dependencies are included (https://github.com/apache/cordova-android/blob/master/bin/templates/cordova/lib/build.js#L244). So `build-extras.gradle` is required to fix this.

2. Since default cordova gradle config includes `libs/*.jars` we will end up w/ mulriple definitions problem so we add special line to NOT include duplicate 'FacebookLib/libs/*.jar' files
```
configurations.compile.dependencies.clear()
```

3. Minor fix for Ant not to fail on post build step.

PS. Adding dependencies via corresponding gradle configuration is the only way to support multiple plugins which rely on the same dependency. If you use 'libs' folder then it will fail as gradle won't be able to rely on its smart [Dependency Managment/Versioning logic](https://docs.gradle.org/current/userguide/dependency_management.html)