### PR TITLE
Replaces Facebook SDK code with gradle dependency

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -21,8 +21,8 @@
 
     <engines>
         <!-- Requires > 3.3.* because of the custom Framework tag for iOS [CB-5238] -->
-        <!-- Requires > 3.5.0 because of the custom Framework tag for Android [CB-6698] -->
-        <engine name="cordova" version=">=3.5.0" />
+        <!-- Requires > 4.3.0 because of the Gradle libs support via Framework tag for Android [CB-8390] -->
+        <engine name="cordova-plugman" version=">=4.3.0" />
     </engines>
 
     <!-- JavaScript interface -->
@@ -57,7 +57,8 @@
             <activity android:label="@string/fb_app_name" android:name="com.facebook.LoginActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar"></activity>
         </config-file>
 
-        <framework src="platforms/android/FacebookLib" custom="true" />
+        <!-- Facebook Android SDK (Feb, 2015) -->
+        <framework src="com.facebook.android:facebook-android-sdk:3.23.0" />
 
         <!-- cordova plugin src files -->
         <source-file src="platforms/android/src/org/apache/cordova/facebook/ConnectPlugin.java" target-dir="src/org/apache/cordova/facebook" />


### PR DESCRIPTION
As per https://github.com/Wizcorp/phonegap-facebook-plugin/issues/1128

Note:  I've left original SDK folder and other files as-is as looks like they are used to develop plugin (`ConnectPlugin.java`). But technically plugin requires only the following three files from `android` folder:
```
 \android\src\org\apache\cordova\facebook\ConnectPlugin.java
 \android\res\values\facebookconnect.xml
 \android\README.md
```

Tested build and run on Nexus5: `connect` and `getLoginStatus` api

Note: I've also replaced engine check from `cordova` to `cordova-plugman` as there is the following issue: https://issues.apache.org/jira/browse/CB-9815 (also `cordova-plugman` is more correct here as restrictions came from plugman functionality)
