### PR TITLE
comparison of constant 2 with boolean expression is always false

### DIFF
--- a/platforms/ios/HelloCordova/Plugins/com.phonegap.plugins.facebookconnect/FacebookConnectPlugin.m
+++ b/platforms/ios/HelloCordova/Plugins/com.phonegap.plugins.facebookconnect/FacebookConnectPlugin.m
@@ -235,7 +235,7 @@
      there is a helper method that explicitly takes a currency indicator.
      */
     CDVPluginResult *res;
-    if (!command.arguments == 2) {
+    if ([command.arguments count] == 2) {
         res = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid arguments"];
         [self.commandDelegate sendPluginResult:res callbackId:command.callbackId];
         return;


### PR DESCRIPTION
Hey there, my currently ios build is breaking because of this line, it should definitly not look like this. :)

./platforms/ios/RunningFitness/Plugins/phonegap-facebook-plugin/FacebookConnectPlugin.m:238:28: warning: comparison of constant 2 with boolean expression is always false [-Wtautological-constant-out-of-range-compare]
    if (!command.arguments == 2) {
        ~~~~~~~~~~~~~~~~~~ ^  ~
1 warning and 1 error generated.
